### PR TITLE
fix: use correct Docker images and flags for Linux targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          # macOS builds disabled in CI due to billing - still enabled in release
+          # macOS x64 disabled in CI due to billing - still enabled in release
           # - host: macos-latest-large
           #   build: npm run build -- --target x86_64-apple-darwin
           #   target: x86_64-apple-darwin
-          # - host: macos-latest
-          #   build: npm run build -- --target aarch64-apple-darwin
-          #   target: aarch64-apple-darwin
+          - host: macos-latest
+            build: npm run build -- --target aarch64-apple-darwin
+            target: aarch64-apple-darwin
           - host: windows-latest
             build: npm run build
             target: x86_64-pc-windows-msvc
@@ -48,7 +48,7 @@ jobs:
               rustup update stable &&
               rustup target add aarch64-unknown-linux-gnu &&
               npm run build -- --target aarch64-unknown-linux-gnu --zig &&
-              aarch64-unknown-linux-gnu-strip *.node
+              llvm-strip *.node
 
     name: stable - ${{ matrix.settings.target }} - node@18
     runs-on: ${{ matrix.settings.host }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
               rustup update stable &&
               rustup target add aarch64-unknown-linux-gnu &&
               npm run build -- --target aarch64-unknown-linux-gnu --zig &&
-              aarch64-unknown-linux-gnu-strip *.node
+              llvm-strip *.node
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine-zig


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled macOS x86_64 CI while keeping macOS aarch64 enabled.
  * Switched primary musl Linux build to x86_64 and added explicit musl build steps.
  * Added a Zig-based aarch64-unknown-linux-gnu build variant.
  * Updated Docker images, toolchain setup, build flags, and artifact stripping.

* **Tests**
  * macOS entries in test matrices temporarily disabled (billing-related).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->