### PR TITLE
feat: surface token usage in responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.15] - 2026-06-02
+
+### Added
+- Token usage reporting: `TextToCypherResponse` now includes an optional `tokenUsage`
+  field aggregating `promptTokens`, `completionTokens`, and `totalTokens` across all LLM
+  calls made while serving a request (cypher generation, final answer, self-healing
+  retries, and skill tool-call rounds). Present on successful responses and omitted when
+  no tokens were consumed.
+
+### Changed
+- Bumped the `text-to-cypher` Rust dependency to `0.1.18`.
+
 ## [0.1.10] - 2026-01-12
 
 ### Added
@@ -60,4 +72,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Proper error handling and propagation from Rust to JavaScript
 - Zero runtime dependencies
 
+[0.1.15]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.15
 [0.1.0]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "genai"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9ea282799f5c6cf09143897251c495883204f04b1db80ab94d80f959ba5962"
+checksum = "1c978ef2c3b5ece57bf0ec25fdd93812ac941c44a569c63ded3ef877907758fa"
 dependencies = [
  "base64",
  "bytes",
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e954ac934faafbf54435d1f242f31f602fcf7d572bfedf9ae3a78a7b60d038e"
+checksum = "614d250eca7e24fa2364d9b7828632a6dc625a523bcadabb1a1145619339df5c"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher-node"
-version = "0.1.12"
+version = "0.1.15"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ napi-derive = "3"
 # Disable default features to avoid including server dependencies (actix-web, etc.)
 # We only need the core library functionality for the bindings
 # Explicitly set features to empty array to ensure no features are enabled
-text-to-cypher = { version = "0.1.17", default-features = false, features = [] }
+text-to-cypher = { version = "0.1.18", default-features = false, features = [] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher-node"
-version = "0.1.12"
+version = "0.1.15"
 edition = "2021"
 authors = ["FalkorDB"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -216,8 +216,21 @@ interface TextToCypherResponse {
   cypherResult?: string;    // Query execution result
   answer?: string;          // Natural language answer
   error?: string;           // Error message if status is "error"
+  tokenUsage?: TokenUsage;  // Aggregated LLM token usage (omitted when no tokens were spent)
+}
+
+interface TokenUsage {
+  promptTokens: number;     // Total input (prompt) tokens across all LLM calls
+  completionTokens: number; // Total output (completion) tokens across all LLM calls
+  totalTokens: number;      // Total tokens across all LLM calls
 }
 ```
+
+`tokenUsage` aggregates the prompt, completion, and total tokens reported by the LLM
+provider across every call made while serving a request (cypher generation, the final
+answer, self-healing retries, and skill tool-call rounds). It is present on successful
+responses and omitted when no tokens were consumed. Failed requests reject with an error,
+so `tokenUsage` is not surfaced for failures.
 
 ### Message
 

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TextToCypher } from '../index';
+import type { TextToCypherResponse, TokenUsage } from '../index';
 
 describe('TextToCypher', () => {
   describe('constructor', () => {
@@ -197,6 +198,36 @@ describe('TextToCypher', () => {
       await expect(
         client.listModelsByProvider('invalid-provider')
       ).rejects.toThrow(/Unknown provider/);
+    });
+  });
+
+  describe('TokenUsage', () => {
+    it('should expose an optional tokenUsage field on the response type', () => {
+      const usage: TokenUsage = {
+        promptTokens: 10,
+        completionTokens: 5,
+        totalTokens: 15,
+      };
+
+      const response: TextToCypherResponse = {
+        status: 'success',
+        answer: 'ok',
+        tokenUsage: usage,
+      };
+
+      expect(response.tokenUsage).toBeDefined();
+      expect(response.tokenUsage?.promptTokens).toBe(10);
+      expect(response.tokenUsage?.completionTokens).toBe(5);
+      expect(response.tokenUsage?.totalTokens).toBe(15);
+    });
+
+    it('should allow responses without tokenUsage', () => {
+      const response: TextToCypherResponse = {
+        status: 'error',
+        error: 'boom',
+      };
+
+      expect(response.tokenUsage).toBeUndefined();
     });
   });
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -215,4 +215,25 @@ export interface TextToCypherResponse {
   answer?: string
   /** Error message if status is "error" */
   error?: string
+  /**
+   * Aggregated token usage across all LLM calls made while serving the request.
+   * Omitted when no tokens were consumed (e.g. failures before any LLM call).
+   */
+  tokenUsage?: TokenUsage
+}
+
+/**
+ * Aggregated token usage for a text-to-cypher request
+ *
+ * A single request may issue several LLM calls (cypher generation, final answer
+ * generation, self-healing retries, and skill tool-call rounds). These counts are
+ * summed across all of those calls.
+ */
+export interface TokenUsage {
+  /** Total input (prompt) tokens consumed across all LLM calls */
+  promptTokens: number
+  /** Total output (completion) tokens produced across all LLM calls */
+  completionTokens: number
+  /** Total tokens consumed across all LLM calls */
+  totalTokens: number
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,35 @@ pub struct Message {
     pub content: String,
 }
 
+/// Aggregated token usage for a text-to-cypher request
+///
+/// A single request may issue several LLM calls (cypher generation, final answer
+/// generation, self-healing retries, and skill tool-call rounds). These counts are
+/// summed across all of those calls.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct TokenUsage {
+    /// Total input (prompt) tokens consumed across all LLM calls
+    pub prompt_tokens: f64,
+    /// Total output (completion) tokens produced across all LLM calls
+    pub completion_tokens: f64,
+    /// Total tokens consumed across all LLM calls
+    pub total_tokens: f64,
+}
+
+impl From<text_to_cypher::TokenUsage> for TokenUsage {
+    fn from(usage: text_to_cypher::TokenUsage) -> Self {
+        Self {
+            prompt_tokens: usage.prompt_tokens as f64,
+            completion_tokens: usage.completion_tokens as f64,
+            total_tokens: usage.total_tokens as f64,
+        }
+    }
+}
+
 /// Response from text-to-cypher operations
 #[napi(object)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct TextToCypherResponse {
     /// Status of the operation: "success" or "error"
     pub status: String,
@@ -43,6 +69,9 @@ pub struct TextToCypherResponse {
     pub answer: Option<String>,
     /// Error message if status is "error"
     pub error: Option<String>,
+    /// Aggregated token usage across all LLM calls made while serving the request.
+    /// Omitted when no tokens were consumed (e.g. failures before any LLM call).
+    pub token_usage: Option<TokenUsage>,
 }
 
 impl From<text_to_cypher::TextToCypherResponse> for TextToCypherResponse {
@@ -54,6 +83,7 @@ impl From<text_to_cypher::TextToCypherResponse> for TextToCypherResponse {
             cypher_result: response.cypher_result,
             answer: response.answer,
             error: response.error,
+            token_usage: response.token_usage.map(Into::into),
         }
     }
 }


### PR DESCRIPTION
## Summary

Ports the token-usage reporting feature from the upstream `text-to-cypher` Rust crate ([FalkorDB/text-to-cypher#128](https://github.com/FalkorDB/text-to-cypher/pull/128), released in **0.1.18**) to these Node bindings.

A single text-to-cypher request can issue several LLM calls (cypher generation, final answer generation, self-healing retries, and skill tool-call rounds). Upstream 0.1.18 aggregates the prompt/completion/total tokens reported by `genai` across all of those calls and exposes them via an optional `token_usage` field on `TextToCypherResponse`. This PR surfaces that field to Node consumers.

## Changes

- **`Cargo.toml` / `Cargo.lock`:** bump `text-to-cypher` `0.1.17` -> `0.1.18` (pulls in the new `TokenUsage` type and the optional `token_usage` field; `genai` updated `0.6.1` -> `0.6.4` transitively).
- **`src/lib.rs`:** add a `#[napi(object)] TokenUsage { promptTokens, completionTokens, totalTokens }` (exposed as JS `number`s) with a `From<text_to_cypher::TokenUsage>` conversion, and an optional `tokenUsage` field on the Node `TextToCypherResponse`. The mapping lives in the shared `From` conversion, so it applies to `textToCypher`, `textToCypherWithMessages`, and `cypherOnly`.
- **`index.d.ts`:** regenerated by `napi build` (adds `tokenUsage?: TokenUsage` and the `TokenUsage` interface).
- **`README.md`:** documents the new fields and behavior.
- **`__test__/index.test.ts`:** tests covering the `tokenUsage` response shape.

## Design notes

- **`number` (f64) representation:** the upstream counts are `u64`, but token usage is a metric (not an identifier) and realistic per-request counts are far below `Number.MAX_SAFE_INTEGER`, so a plain JS `number` is the most ergonomic choice (a NAPI `BigInt` would be awkward to consume and JSON-serialize).
- **Error paths:** the binding wraps the upstream `TextToCypherClient`, whose methods convert error-status responses into thrown errors. This matches the existing reject-on-error Node API, so `tokenUsage` is surfaced on successful responses only - consistent with the upstream client's own behavior.
- **`index.js`:** unchanged - the new types are TypeScript-only objects with no runtime JS; regeneration only produced version-string noise.

## Backward compatibility

The new field is optional, so existing consumers are unaffected.

## Testing

- `npm run build` (release) succeeds.
- `npm test` - 15 passed, 5 skipped (live-credential tests).
- A rubber-duck review was incorporated (confirmed the `number` representation, validated the shared `From` mapping covers all success paths, and documented the error-path behavior).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token usage reporting to API responses with detailed metrics for prompt tokens, completion tokens, and total consumption across requests
  * Token usage is optional and calculated from aggregated counts across all internal LLM operations
  * Excluded from responses when zero tokens were consumed

* **Tests**
  * Added tests verifying token usage field behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->