### PR TITLE
Add LLM endpoint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.17] - 2026-06-10
+
+### Added
+- Added `llmEndpoint` client option for OpenAI-compatible local providers such as LM Studio.
+- Added support for `openai:` single-colon model prefixes in addition to `openai::`.
+
+### Changed
+- Bumped the `text-to-cypher` Rust dependency to `0.1.20`.
+
 ## [0.1.16] - 2026-06-03
 
 ### Added
@@ -87,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Proper error handling and propagation from Rust to JavaScript
 - Zero runtime dependencies
 
+[0.1.17]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.17
 [0.1.16]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.16
 [0.1.15]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.15
 [0.1.0]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher-node"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "genai"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c978ef2c3b5ece57bf0ec25fdd93812ac941c44a569c63ded3ef877907758fa"
+checksum = "1d12aba7e9dc2c4d54654566dc3dc8383b5cb52e0cfc5754989afe0480d933e3"
 dependencies = [
  "base64",
  "bytes",
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368fcc15d77c6fb1cc32183f76d92191aa947666f5dbf05eec9328cd552a594f"
+checksum = "8c026245eb81c88f71c465ca570a355c38cede1907de3681638c178ab814a3e4"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ napi-derive = "3"
 # Disable default features to avoid including server dependencies (actix-web, etc.)
 # We only need the core library functionality for the bindings
 # Explicitly set features to empty array to ensure no features are enabled
-text-to-cypher = { version = "0.1.19", default-features = false, features = [] }
+text-to-cypher = { version = "0.1.20", default-features = false, features = [] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher-node"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 authors = ["FalkorDB"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ main().catch(console.error);
 Creates a new text-to-cypher client.
 
 **Parameters:**
-- `options.model` (string): AI model to use (e.g., `'gpt-4o-mini'`, `'anthropic:claude-3'`, `'gemini:gemini-2.0-flash-exp'`)
+- `options.model` (string): AI model to use (e.g., `'gpt-4o-mini'`, `'openai:local-model'`, `'anthropic:claude-3'`, `'gemini:gemini-2.0-flash-exp'`)
 - `options.apiKey` (string): API key for the AI service
 - `options.falkordbConnection` (string): FalkorDB connection string (e.g., `'falkor://localhost:6379'`)
 - `options.llmEndpoint` (string, optional): Custom LLM provider endpoint/base URL for OpenAI-compatible local providers such as LM Studio (e.g., `'http://localhost:1234/v1'`)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Creates a new text-to-cypher client.
 - `options.model` (string): AI model to use (e.g., `'gpt-4o-mini'`, `'anthropic:claude-3'`, `'gemini:gemini-2.0-flash-exp'`)
 - `options.apiKey` (string): API key for the AI service
 - `options.falkordbConnection` (string): FalkorDB connection string (e.g., `'falkor://localhost:6379'`)
+- `options.llmEndpoint` (string, optional): Custom LLM provider endpoint/base URL for OpenAI-compatible local providers such as LM Studio (e.g., `'http://localhost:1234/v1'`)
 
 **Example:**
 ```javascript
@@ -66,6 +67,17 @@ const client = new TextToCypher({
   model: 'gpt-4o-mini',
   apiKey: 'sk-...',
   falkordbConnection: 'falkor://localhost:6379'
+});
+```
+
+For LM Studio or another OpenAI-compatible local server, pass the local endpoint:
+
+```javascript
+const client = new TextToCypher({
+  model: 'openai::google/gemma-4-e4b',
+  apiKey: 'lm-studio',
+  falkordbConnection: 'falkor://localhost:6379',
+  llmEndpoint: 'http://localhost:1234/v1'
 });
 ```
 

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -25,6 +25,7 @@ describe('TextToCypher', () => {
       const models = [
         'gpt-4o-mini',
         'gpt-4o',
+        'openai:local-model',
         'anthropic:claude-3',
         'gemini:gemini-2.0-flash-exp'
       ];
@@ -37,6 +38,17 @@ describe('TextToCypher', () => {
         });
         expect(client).toBeInstanceOf(TextToCypher);
       });
+    });
+
+    it('should accept a custom LLM endpoint', () => {
+      const client = new TextToCypher({
+        model: 'openai::local-model',
+        apiKey: 'test-key',
+        falkordbConnection: 'falkor://localhost:6379',
+        llmEndpoint: 'http://localhost:1234/v1'
+      });
+
+      expect(client).toBeInstanceOf(TextToCypher);
     });
   });
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -193,6 +193,8 @@ export interface ClientOptions {
   apiKey: string
   /** FalkorDB connection string (e.g., "falkor://localhost:6379") */
   falkordbConnection: string
+  /** Optional LLM provider endpoint/base URL override */
+  llmEndpoint?: string
 }
 
 /** A chat message in the conversation */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub struct ClientOptions {
     pub api_key: String,
     /// FalkorDB connection string (e.g., "falkor://localhost:6379")
     pub falkordb_connection: String,
+    /// Optional LLM provider endpoint/base URL override
+    pub llm_endpoint: Option<String>,
 }
 
 /// A chat message in the conversation
@@ -94,7 +96,7 @@ fn normalize_model_name(model: &str) -> String {
         return model.to_string();
     }
     // Convert known single-colon provider prefixes to genai's "::" namespace format
-    for prefix in &["anthropic:", "gemini:", "ollama:"] {
+    for prefix in &["openai:", "anthropic:", "gemini:", "ollama:"] {
         if model.starts_with(prefix) {
             let provider = &prefix[..prefix.len() - 1];
             let model_name = &model[prefix.len()..];
@@ -148,11 +150,14 @@ impl TextToCypher {
     #[napi(constructor)]
     pub fn new(options: ClientOptions) -> Result<Self> {
         let model = normalize_model_name(&options.model);
-        let client = TextToCypherClient::new(
+        let mut client = TextToCypherClient::new(
             model,
             options.api_key,
             options.falkordb_connection,
         );
+        if let Some(endpoint) = options.llm_endpoint {
+            client = client.with_llm_endpoint(endpoint);
+        }
 
         Ok(Self { client })
     }


### PR DESCRIPTION
## Summary
- bump text-to-cypher to 0.1.20
- expose optional llmEndpoint through the native Node client
- support openai: single-colon local model names
- add constructor coverage and LM Studio usage docs

## Tests
- cargo check
- npm run build:debug
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `llmEndpoint` parameter to configure custom LLM provider endpoints
  * Expanded model identifier support to include `openai:` prefix format

* **Documentation**
  * Updated README with configuration examples for local LLM providers

* **Chores**
  * Version updated to 0.1.17
  * Updated dependency versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->