### PR TITLE
chore: update text-to-cypher to 0.1.21; re-enable macOS x64 + universal targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,13 +149,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bindings-x86_64-apple-darwin
-          path: artifacts
+          path: .
 
       - name: Download macOS arm64 artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bindings-aarch64-apple-darwin
-          path: artifacts
+          path: .
 
       - name: Combine binaries
         run: npm run universal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest-large
+          # macos-15-intel: free standard Intel runner (builds x86_64 natively).
+          # Replaces the retired macos-13 and the paid macos-latest-large.
+          # NOTE: GitHub sunsets all Intel macOS runners ~Aug 2027; migrate x64 to an
+          # arm64 cross-build (or drop the target) before then.
+          - host: macos-15-intel
             build: npm run build -- --target x86_64-apple-darwin
             target: x86_64-apple-darwin
           - host: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          # macOS x64 disabled due to billing issues
-          # - host: macos-latest-large
-          #   build: npm run build -- --target x86_64-apple-darwin
-          #   target: x86_64-apple-darwin
+          - host: macos-latest-large
+            build: npm run build -- --target x86_64-apple-darwin
+            target: x86_64-apple-darwin
           - host: macos-latest
             build: npm run build -- --target aarch64-apple-darwin
             target: aarch64-apple-darwin
@@ -120,47 +119,45 @@ jobs:
           path: text-to-cypher.*.node
           if-no-files-found: error
 
-  # universal-macOS job disabled - requires both x64 and ARM64 builds
-  # Currently x64 is disabled due to billing issues
-  # universal-macOS:
-  #   name: Build universal macOS binary
-  #   needs:
-  #     - build
-  #   runs-on: macos-latest
-  #
-  #   steps:
-  #     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-  #
-  #     - name: Setup node
-  #       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-  #       with:
-  #         node-version: 20
-  #         cache: npm
-  #
-  #     - name: Install dependencies
-  #       run: npm install
-  #
-  #     - name: Download macOS x64 artifact
-  #       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-  #       with:
-  #         name: bindings-x86_64-apple-darwin
-  #         path: artifacts
-  #
-  #     - name: Download macOS arm64 artifact
-  #       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-  #       with:
-  #         name: bindings-aarch64-apple-darwin
-  #         path: artifacts
-  #
-  #     - name: Combine binaries
-  #       run: npm run universal
-  #
-  #     - name: Upload artifact
-  #       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-  #       with:
-  #         name: bindings-universal-apple-darwin
-  #         path: text-to-cypher.*.node
-  #         if-no-files-found: error
+  universal-macOS:
+    name: Build universal macOS binary
+    needs:
+      - build
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Download macOS x64 artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bindings-x86_64-apple-darwin
+          path: artifacts
+
+      - name: Download macOS arm64 artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bindings-aarch64-apple-darwin
+          path: artifacts
+
+      - name: Combine binaries
+        run: npm run universal
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bindings-universal-apple-darwin
+          path: text-to-cypher.*.node
+          if-no-files-found: error
 
   publish:
     name: Publish to npm
@@ -170,7 +167,7 @@ jobs:
       id-token: write
     needs:
       - build
-      # - universal-macOS
+      - universal-macOS
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,13 @@ jobs:
 
     name: stable - ${{ matrix.settings.target }} - node@20
     runs-on: ${{ matrix.settings.host }}
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -124,9 +128,13 @@ jobs:
     needs:
       - build
     runs-on: macos-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bindings-universal-apple-darwin
-          path: text-to-cypher.*.node
+          path: text-to-cypher.darwin-universal.node
           if-no-files-found: error
 
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Proper error handling and propagation from Rust to JavaScript
 - Zero runtime dependencies
 
+[0.1.18]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.18
 [0.1.17]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.17
 [0.1.16]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.16
 [0.1.15]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.18] - 2026-06-20
+
+### Changed
+- Bumped the `text-to-cypher` Rust dependency to `0.1.21` — brings falkordb-rs `0.8.9`, a
+  read-only retry policy, and gated FalkorDB tracing under the hood. The binding's public TypeScript
+  API is unchanged (patch release).
+
+### CI
+- Re-enabled the macOS **x64** and **universal-apple-darwin** release targets (previously disabled).
+
 ## [0.1.17] - 2026-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +33,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +57,17 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -100,18 +117,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
+name = "backon"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
+ "fastrand",
+ "tokio",
 ]
 
 [[package]]
@@ -169,6 +181,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +313,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "ctor"
@@ -421,6 +468,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eventsource-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,29 +501,31 @@ dependencies = [
 
 [[package]]
 name = "falkordb"
-version = "0.2.1"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33533867b0cc0472576ead2151ea335e0bd1e81b88aae45ccd8a1c99c170882c"
+checksum = "b511c066745e2326bcd72f98cb41f0081d8fa03dff8a1506da7c1c3c1afbd460"
 dependencies = [
+ "backon",
+ "futures-core",
  "parking_lot",
  "redis",
  "regex",
- "strum 0.27.2",
+ "strum",
  "thiserror 2.0.18",
  "tokio",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -601,7 +671,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "strum 0.28.0",
+ "strum",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -645,15 +715,10 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
@@ -1207,29 +1272,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -1238,15 +1284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1260,6 +1297,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1277,10 +1320,8 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "backtrace",
  "cfg-if",
  "libc",
- "petgraph",
  "redox_syscall",
  "smallvec",
  "windows-link",
@@ -1297,16 +1338,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.13.0",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1393,7 +1424,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1447,7 +1478,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1457,7 +1499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1470,25 +1512,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis"
-version = "0.32.7"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "redis"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae41a63fd0b8a5372f82b21e810e09a316f5dd7efd96bf08e678fb240fc1918"
 dependencies = [
+ "arc-swap",
+ "arcstr",
+ "async-lock",
+ "backon",
  "bytes",
  "cfg-if",
  "combine",
+ "futures-channel",
  "futures-util",
  "itoa",
- "num-bigint",
+ "log",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.10.1",
  "ryu",
  "socket2",
  "tokio",
  "tokio-util",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -1605,12 +1659,6 @@ dependencies = [
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -1936,32 +1984,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]
@@ -2036,9 +2063,8 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c026245eb81c88f71c465ca570a355c38cede1907de3681638c178ab814a3e4"
+version = "0.1.21"
+source = "git+https://github.com/FalkorDB/text-to-cypher?rev=ad2179c80170504db7cb8d46cbca701b5ecf851d#ad2179c80170504db7cb8d46cbca701b5ecf851d"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -2049,14 +2075,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "strum 0.28.0",
+ "strum",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "text-to-cypher-node"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "napi",
  "napi-build",
@@ -2966,6 +2992,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,8 @@ dependencies = [
 [[package]]
 name = "text-to-cypher"
 version = "0.1.21"
-source = "git+https://github.com/FalkorDB/text-to-cypher?rev=ad2179c80170504db7cb8d46cbca701b5ecf851d#ad2179c80170504db7cb8d46cbca701b5ecf851d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4901619f0aa53b8f672e6d867429f0eb3e5b2aed7816b57980f6d4cf088c41ac"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,7 @@ napi-derive = "3"
 # Disable default features to avoid including server dependencies (actix-web, etc.)
 # We only need the core library functionality for the bindings
 # Explicitly set features to empty array to ensure no features are enabled
-#
-# NOTE: text-to-cypher 0.1.21 is not on crates.io yet — pinned to the 0.1.21 release
-# commit via git so this builds now. Switch back to `version = "0.1.21"` once it is
-# published to crates.io (see the PR "Before merge" checklist).
-text-to-cypher = { git = "https://github.com/FalkorDB/text-to-cypher", rev = "ad2179c80170504db7cb8d46cbca701b5ecf851d", default-features = false, features = [] }
+text-to-cypher = { version = "0.1.21", default-features = false, features = [] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher-node"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 authors = ["FalkorDB"]
 license = "MIT"
@@ -17,7 +17,11 @@ napi-derive = "3"
 # Disable default features to avoid including server dependencies (actix-web, etc.)
 # We only need the core library functionality for the bindings
 # Explicitly set features to empty array to ensure no features are enabled
-text-to-cypher = { version = "0.1.20", default-features = false, features = [] }
+#
+# NOTE: text-to-cypher 0.1.21 is not on crates.io yet — pinned to the 0.1.21 release
+# commit via git so this builds now. Switch back to `version = "0.1.21"` once it is
+# published to crates.io (see the PR "Before merge" checklist).
+text-to-cypher = { git = "https://github.com/FalkorDB/text-to-cypher", rev = "ad2179c80170504db7cb8d46cbca701b5ecf851d", default-features = false, features = [] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## What

Updates the napi binding (`@falkordb/text-to-cypher`) to the latest **text-to-cypher `0.1.21`**, bumps the package to **`0.1.18`**, and **re-enables the macOS x64 + universal-apple-darwin** release targets — all in one PR.

## Changes
1. **Dependency → `text-to-cypher 0.1.21`** (published to crates.io). Transitively brings **falkordb-rs `0.8.9`**, a read-only retry policy, and gated FalkorDB tracing. **The binding's public TypeScript API is unchanged** (no `src/lib.rs` changes; `index.d.ts` untouched) → patch release.
2. **Version `0.1.17` → `0.1.18`** + `CHANGELOG`.
3. **Re-enabled macOS `x86_64-apple-darwin` + `universal-apple-darwin`** in `release.yml` (build matrix entry + the `universal-macOS` job + its `needs:` in `publish`). x64 builds on the **free `macos-15-intel`** standard runner.

## Validation
- `cargo check` is **clean** against `text-to-cypher 0.1.21` from crates.io (resolves `falkordb 0.8.9`) — confirms the upstream "keep FalkorDB out of the public API" refactor doesn't affect the binding.
- Feature hygiene confirmed: with `default-features = false`, the server/tracing deps are **absent** (`actix-web`, `utoipa`, `tracing-subscriber`, `dashmap`); `text-to-cypher` resolves to `0.1.21`, `falkordb` to `0.8.9`.
- Full native cross-builds + tests run in CI (`ci.yml` gate; `release.yml` builds all targets on release).

## ✅ Before merge — done
- [x] **Published `text-to-cypher 0.1.21` to crates.io.** Tagged `v0.1.21` at the **release commit `ad2179c`** (the exact rev this binding was built/validated against — master has since drifted past it with an unreleased feature, so the tag was anchored to the release commit, not HEAD). `cargo publish` succeeded; `0.1.21` is live (not yanked).
- [x] **Flipped the dep** from the git `rev` pin to `text-to-cypher = { version = "0.1.21", default-features = false, features = [] }` + `cargo update`; `Cargo.lock` now resolves from the registry (checksum), `cargo check` clean.
- [x] **macOS x64 runner.** Switched from the **paid `macos-latest-large`** (the original "billing issues" cause) to the **free standard `macos-15-intel`** — native x86_64 build, the official replacement for the retired `macos-13`. ⚠️ GitHub sunsets all Intel macOS runners ~**Aug 2027**; migrate x64 to an arm64 cross-build (or drop the target) before then.

> Only remaining merge gate: a required **approving review** (branch protection — author can't self-approve). All status checks (CI, CodeQL, CodeRabbit) are green.

## Notes
- Downstream: `falkordb-browser` depends on `@falkordb/text-to-cypher@^0.1.17`, which already admits `0.1.18` — can bump the floor separately if desired.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released **v0.1.18**
  * Updated the **text-to-cypher** dependency to **0.1.21**
* **CI / Release Pipeline**
  * Re-enabled **macOS x64** release builds
  * Re-enabled **universal macOS** releases (x64 + ARM64 combined)
  * Adjusted the publish flow to wait for the **universal** artifact before publishing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
