### PR TITLE
chore: bump text-to-cypher core to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "falkordb"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "959ad8ef22720aa5db416422445793590731538b3677852d4f40b75c5e992cdb"
+checksum = "ef252f8895e980db625e2dc8d035f683eccc67cdf26585d4da72ab131af93398"
 dependencies = [
  "backon",
  "futures-core",
@@ -2063,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a29c4f451decf66be3e8c71ead76be5747da2ff9cf3d26e7f4af56d30eb7c4"
+checksum = "16a856bc8d888c066d58d36f11e46596958f2349da233e61457ad0070832b243"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ napi-derive = "3"
 # Disable default features to avoid including server dependencies (actix-web, etc.)
 # We only need the core library functionality for the bindings
 # Explicitly set features to empty array to ensure no features are enabled
-text-to-cypher = { version = "0.2.0", default-features = false, features = [] }
+text-to-cypher = { version = "0.2.1", default-features = false, features = [] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## What

Bumps the `text-to-cypher` core dependency `0.2.0 → 0.2.1` to pull in the UDF prompt fixes.

## Why

Core PR FalkorDB/text-to-cypher#152 fixes two UDF chat issues:
1. **Honor explicitly-requested UDFs** — when the question names a listed function/library, the generated query calls it as `library.function(...)` instead of substituting a built-in operator (e.g. `*`).
2. **Prose answers** — the final answer is natural language, never a raw Cypher query.

## Changes

- `Cargo.toml`: `text-to-cypher = "0.2.1"`
- `Cargo.lock`: resolves `text-to-cypher v0.2.1` from crates.io

No binding source/logic changes — the fixes are in the core crate's prompt templates, which compile into the native `.node` binary when the bindings are rebuilt/republished.

## Validation

- `cargo check` compiles cleanly against `text-to-cypher v0.2.1`.
- Verified end-to-end earlier (gpt-4o-mini + real FalkorDB) against a local build of 0.2.1: UDF queries call the UDF, non-UDF queries are unaffected, answers are prose.

## Note

Native binaries must be rebuilt/republished (napi) for the new prompt text to ship; consumers (e.g. falkordb-browser) then bump the npm version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a third-party dependency to the latest patch release for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->