### PR TITLE
Expose answer confidence score in Node.js binding (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-07-05
+
+### Added
+- **Answer confidence**: responses now include a model self-reported confidence score (0-100)
+  for each answer.
+
+### Changed
+- Bumped the `text-to-cypher` Rust dependency to `0.2.2` (readable shortest-path results and the
+  new answer-confidence feature). The binding's public TypeScript API is unchanged.
+
 ## [0.2.0] - 2026-06-21
 
 ### Added
@@ -120,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Proper error handling and propagation from Rust to JavaScript
 - Zero runtime dependencies
 
+[0.2.1]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.2.1
 [0.2.0]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.2.0
 [0.1.18]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.18
 [0.1.17]: https://github.com/FalkorDB/text-to-cypher-node/releases/tag/v0.1.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bumped the `text-to-cypher` Rust dependency to `0.2.2` (readable shortest-path results and the
-  new answer-confidence feature). The binding's public TypeScript API is unchanged.
+  new answer-confidence feature). The change is backward-compatible — it only adds the optional
+  `confidence?: number` field to `TextToCypherResponse`.
 
 ## [0.2.0] - 2026-06-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher-node"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher-node"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["FalkorDB"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ napi-derive = "3"
 # Disable default features to avoid including server dependencies (actix-web, etc.)
 # We only need the core library functionality for the bindings
 # Explicitly set features to empty array to ensure no features are enabled
-text-to-cypher = { version = "0.2.1", default-features = false, features = [] }
+text-to-cypher = { version = "0.2.2", default-features = false, features = [] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ interface TextToCypherResponse {
   cypherQuery?: string;     // Generated Cypher query
   cypherResult?: string;    // Query execution result
   answer?: string;          // Natural language answer
+  confidence?: number;      // Model self-reported confidence (0-100) in the answer
   error?: string;           // Error message if status is "error"
   tokenUsage?: TokenUsage;  // Aggregated LLM token usage (omitted when no tokens were spent)
 }

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -322,4 +322,25 @@ describe('TextToCypher', () => {
       expect(response.tokenUsage).toBeUndefined();
     });
   });
+
+  describe('Confidence', () => {
+    it('should expose an optional confidence field on the response type', () => {
+      const response: TextToCypherResponse = {
+        status: 'success',
+        answer: 'The cities are A, B, C, and D.',
+        confidence: 100,
+      };
+
+      expect(response.confidence).toBe(100);
+    });
+
+    it('should allow responses without confidence', () => {
+      const response: TextToCypherResponse = {
+        status: 'success',
+        answer: 'ok',
+      };
+
+      expect(response.confidence).toBeUndefined();
+    });
+  });
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -230,6 +230,11 @@ export interface TextToCypherResponse {
   cypherResult?: string
   /** Natural language answer generated from the results */
   answer?: string
+  /**
+   * Model self-reported confidence (0-100) that the answer is correct given the data.
+   * Omitted when the model does not report a value.
+   */
+  confidence?: number
   /** Error message if status is "error" */
   error?: string
   /**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,9 @@ pub struct TextToCypherResponse {
     pub cypher_result: Option<String>,
     /// Natural language answer generated from the results
     pub answer: Option<String>,
+    /// Model self-reported confidence (0-100) that the answer is correct given the data.
+    /// Omitted when the model does not report a value.
+    pub confidence: Option<u32>,
     /// Error message if status is "error"
     pub error: Option<String>,
     /// Aggregated token usage across all LLM calls made while serving the request.
@@ -118,6 +121,7 @@ impl From<text_to_cypher::TextToCypherResponse> for TextToCypherResponse {
             cypher_query: response.cypher_query,
             cypher_result: response.cypher_result,
             answer: response.answer,
+            confidence: response.confidence.map(u32::from),
             error: response.error,
             token_usage: response.token_usage.map(Into::into),
         }


### PR DESCRIPTION
## Summary

Surfaces the model self-reported **answer confidence score (0–100)** through the Node.js binding, matching the feature added in `text-to-cypher` 0.2.2.

`TextToCypherResponse` now includes an optional `confidence` field that flows core → napi Rust struct → JS. Omitted when the model reports no value.

## Changes (by commit)

- **feat(binding)**: add `confidence: Option<u32>` to the napi response struct + mapping from core
- **feat(types)**: expose `confidence?: number` in `index.d.ts`
- **test**: cover the confidence field on the response type
- **docs(readme)**: document the confidence response field
- **chore(deps)**: bump `text-to-cypher` to `0.2.2`
- **chore(release)**: bump package version to `0.2.1`
- **docs(changelog)**: add `0.2.1` entry

## Testing

Rebuilt the native addon against the local core `0.2.2` and ran real queries through the binding:

| Query | confidence |
|---|---|
| `List all city names.` | `100` |
| `What is the population of city Z?` (no data) | `0` |

TypeScript tests and `tsc` pass.

> Note: `text-to-cypher 0.2.2` must be published to crates.io before this merges cleanly (the runtime test used a local path override, reverted here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **Answer confidence** field to responses, reporting a 0–100 score when available.
  * The confidence value is now included in the TypeScript API and response output.
* **Documentation**
  * Updated the README and changelog to document the new confidence field and the 0.2.1 release.
* **Tests**
  * Expanded tests to confirm confidence is present when provided and omitted when not available.
* **Chores**
  * Updated the package version and refreshed the underlying dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->