### PR TITLE
Bump text-to-cypher dependency to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a856bc8d888c066d58d36f11e46596958f2349da233e61457ad0070832b243"
+checksum = "516a6fde27e7daf0ffeacbdad7e358a30ff29db3e714d2836e33cfef02c2f2c5"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher-node"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ napi-derive = "3"
 # Disable default features to avoid including server dependencies (actix-web, etc.)
 # We only need the core library functionality for the bindings
 # Explicitly set features to empty array to ensure no features are enabled
-text-to-cypher = { version = "0.2.2", default-features = false, features = [] }
+text-to-cypher = { version = "0.2.4", default-features = false, features = [] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher-node"
-version = "0.2.1"
+version = "0.2.3"
 edition = "2021"
 authors = ["FalkorDB"]
 license = "MIT"


### PR DESCRIPTION
Updates the text-to-cypher crate from 0.2.2 to 0.2.4, picking up:
- Improved answer confidence scoring: confidence now reflects whether the graph data actually answers the question (non-answers like "information is not available" score low instead of 100)
- Readable shortest-path results (node names projected instead of bare path objects)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to `0.2.3`.
  * Bumped a core dependency to a newer compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->